### PR TITLE
Remove table from database before scraping

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -59,7 +59,7 @@ def scrape_list(url, term)
   end
 end
 
-ScraperWiki.sqliteexecute('DELETE FROM data') rescue nil
+ScraperWiki.sqliteexecute('DROP TABLE data') rescue nil
 scrape_table_elected('https://en.wikipedia.org/wiki/Pitcairn_Islands_general_election,_2013', '2013')
 scrape_list('https://en.wikipedia.org/wiki/Pitcairn_Islands_general_election,_2011', '2011')
 scrape_table_green('https://en.wikipedia.org/wiki/Pitcairn_Islands_general_election,_2009', '2009')


### PR DESCRIPTION
SqliteMagic creates a unique index at CREATE TABLE time. This means that if the unique index arguments of ScraperWiki.save_sqlite change, we need to create a new table to ensure the db reflects the change. Part of: https://github.com/everypolitician/everypolitician/issues/593